### PR TITLE
feat: upgrade to KeeperRegistry 2.0

### DIFF
--- a/contracts/DssVestTopUp.sol
+++ b/contracts/DssVestTopUp.sol
@@ -19,18 +19,23 @@ interface DaiJoinLike {
 }
 
 interface KeeperRegistryLike {
-    function getUpkeep(uint256 id)
+    struct UpkeepInfo {
+        address target;
+        uint32 executeGas;
+        bytes checkData;
+        uint96 balance;
+        address admin;
+        uint64 maxValidBlocknumber;
+        uint32 lastPerformBlockNumber;
+        uint96 amountSpent;
+        bool paused;
+        bytes offchainConfig;
+    }
+
+    function getUpkeep(uint256)
         external
         view
-        returns (
-            address target,
-            uint32 executeGas,
-            bytes memory checkData,
-            uint96 balance,
-            address lastKeeper,
-            address admin,
-            uint64 maxValidBlocknumber
-        );
+        returns (UpkeepInfo memory upkeepInfo);
 
     function addFunds(uint256 id, uint96 amount) external;
 }
@@ -154,7 +159,7 @@ contract DssVestTopUp is IUpkeepRefunder, Ownable {
      * if there's enough unpaid vested tokens or tokens in the contract balance
      */
     function shouldRefundUpkeep() public view initialized returns (bool) {
-        (, , , uint96 balance, , , ) = keeperRegistry.getUpkeep(upkeepId);
+        uint96 balance = keeperRegistry.getUpkeep(upkeepId).balance;
         if (
             threshold < balance ||
             (dssVest.unpaid(vestId) < minWithdrawAmt &&

--- a/contracts/test/KeeperRegistryMock.sol
+++ b/contracts/test/KeeperRegistryMock.sol
@@ -4,20 +4,36 @@ pragma solidity ^0.8.9;
 contract KeeperRegistryMock {
     uint96 private upkeepBalance;
 
+    struct UpkeepInfo {
+        address target;
+        uint32 executeGas;
+        bytes checkData;
+        uint96 balance;
+        address admin;
+        uint64 maxValidBlocknumber;
+        uint32 lastPerformBlockNumber;
+        uint96 amountSpent;
+        bool paused;
+        bytes offchainConfig;
+    }
+
     function getUpkeep(uint256)
         external
         view
-        returns (
-            address target,
-            uint32 executeGas,
-            bytes memory checkData,
-            uint96 balance,
-            address lastKeeper,
-            address admin,
-            uint64 maxValidBlocknumber
-        )
+        returns (UpkeepInfo memory upkeepInfo)
     {
-        return (address(0), 0, "", upkeepBalance, address(0), address(0), 0);
+        upkeepInfo = UpkeepInfo({
+            target: address(0x0),
+            executeGas: 0,
+            checkData: "",
+            balance: upkeepBalance,
+            admin: address(0),
+            maxValidBlocknumber: 0,
+            lastPerformBlockNumber: 0,
+            amountSpent: 0,
+            paused: false,
+            offchainConfig: ""
+        });
     }
 
     function addFunds(uint256, uint96 amount) external {

--- a/scripts/deploy_staging.ts
+++ b/scripts/deploy_staging.ts
@@ -113,7 +113,7 @@ async function main() {
     dssVest.address
   );
   const DaiJoinMock = await ethers.getContractFactory("DaiJoinMock");
-  const daiJoinMock = await DaiJoinMock.deploy();
+  const daiJoinMock = await DaiJoinMock.deploy(paymentToken.address);
   await daiJoinMock.deployed();
 
   const DssVestTopUp = await ethers.getContractFactory("DssVestTopUp");


### PR DESCRIPTION
Changes DssVestTopUp's KeeperRegistryLike and KeeperRegistryMock so we can use KeeperRegistry 2.0 in future branches. 